### PR TITLE
Raise an exception when the name of github seeds are invalid.

### DIFF
--- a/lib/cocoaseeds/core.rb
+++ b/lib/cocoaseeds/core.rb
@@ -200,6 +200,10 @@ module Seeds
           target *self.project.targets.map(&:name) do
             send(__callee__, repo, tag, options)
           end
+        elsif repo.split('/').count != 2
+          raise Seeds::Exception.new\
+          "#{repo}: GitHub should have both username and repo name.\n"\
+          "    (e.g. `devxoul/JLToast`)"
         else
           seed = Seeds::Seed::GitHub.new
           seed.url = "https://github.com/#{repo}"

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -61,6 +61,13 @@ class CoreTest < Minitest::Test
     assert_raises Seeds::Exception do @seed.install end
   end
 
+  def test_raise_invalid_github_reponame
+    seedfile %{
+      github "JLToast", "1.2.2"
+    }
+    assert_raises Seeds::Exception do @seed.install end
+  end
+
   def test_install
     seedfile %{
       github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"


### PR DESCRIPTION
Raise an exception when github seed names don't have username.

``` ruby
github "SwiftyJSON", "2.2.0", :files => "Source/SwiftyJSON.swift"
```

![screen shot 2015-06-13 at 11 28 43](https://cloud.githubusercontent.com/assets/931655/8144660/0cd781a0-1224-11e5-980e-f4274c8751bc.png)
- Related issue: #6
