### PR TITLE
Append seed name as a prefix to file name if `swift_seedname_prefix` is set to `true`.

### DIFF
--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -250,4 +250,24 @@ class CoreTest < Minitest::Test
     assert_equal uuids_before, uuids_after
   end
 
+  def test_swift_seedname_prefix
+    seedfile %{
+      swift_seedname_prefix!
+      github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"
+    }
+    @seed.install
+
+    self.project["Seeds"]["JLToast"].files.each do |file|
+      assert_match /(.*\.h|JLToast_.*\.swift)/, file.name
+    end
+
+    self.project.targets.each do |target|
+      phase = target.sources_build_phase
+      assert phase.files.length > 0
+      phase.file_display_names.each do |filename|
+        assert_match /(.*\.h|JLToast_.*\.swift)/, filename
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#### Problem

Xcode raise an compile error if there are multiple files with same name from multiple seeds.
#### Solution

Append seed name as a prefix when including swift files.

e.g.

| Before | After |
| --- | --- |
| `Seeds/Alamofire/Alamofire.swift` | `Seeds/Alamofire/Alamofire_Alamofire.swift` |
| `Seeds/Argo/Operators/Operators.swift` | `Seeds/Argo/Operators/Argo_Operators.swift` |
| `Seeds/Runes/Operators.swift` | `Seeds/Runes/Runes_Operators.swift` |
#### Usage

Since this approach needs more field test, users need to specify `swift_seedname_prefix!` to use this feature.

**Seedfile**

<pre>
<b>swift_seedname_prefix!</b>  # add this line

github "Alamofire/Alamofire", "swift-2.0", :files => "Source/*.swift"
github "thoughtbot/Argo", "td-swift-2", :files => "Argo/*/*.swift"
github "thoughtbot/Runes", "swift-2.0", :files => "Source/*.swift"
</pre>

#### Information
- Related issue: #14
