### PR TITLE
Ensure that UUID's are 24 chars long

### DIFF
--- a/lib/cocoaseeds/core.rb
+++ b/lib/cocoaseeds/core.rb
@@ -333,7 +333,7 @@ module Seeds
       if group
         group.clear
       else
-        uuid = Digest::MD5.hexdigest("Seeds").upcase
+        uuid = Xcodeproj::uuid_with_name "Seeds"
         group = self.project.new_group_with_uuid("Seeds", uuid)
       end
 
@@ -348,13 +348,13 @@ module Seeds
       end
 
       self.source_files.each do |seedname, filepaths|
-        uuid = Digest::MD5.hexdigest("Seeds/#{seedname}").upcase
+        uuid = Xcodeproj::uuid_with_name "Seeds/#{seedname}"
         seedgroup = group[seedname] ||
                     group.new_group_with_uuid(seedname, uuid)
         filepaths.each do |path|
           filename = path.split('/')[-1]
           relpath = path[self.root_path.length..-1]
-          uuid = Digest::MD5.hexdigest(relpath).upcase
+          uuid = Xcodeproj::uuid_with_name relpath
           file_reference = seedgroup[filename] ||
                            seedgroup.new_reference_with_uuid(path, uuid)
           self.file_references << file_reference
@@ -408,7 +408,7 @@ module Seeds
           addings.each do |seed_names|
             next if file.name.end_with? ".h"
             next if not seed_names.include?(file.parent.name)
-            uuid = Digest::MD5.hexdigest("#{target.name}:#{file.name}").upcase
+            uuid = Xcodeproj::uuid_with_name "#{target.name}:#{file.name}"
             phase.add_file_reference_with_uuid(file, uuid, true)
           end
         end

--- a/lib/cocoaseeds/xcodehelper.rb
+++ b/lib/cocoaseeds/xcodehelper.rb
@@ -36,6 +36,10 @@ module Xcodeproj
     end
 
   end
+
+  def self.uuid_with_name(name)
+      Digest::MD5.hexdigest(name).upcase[0,24]
+  end
 end
 
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -221,6 +221,17 @@ class CoreTest < Minitest::Test
       "Group 'Seeds/JLToast' exists in the project."
   end
 
+  def test_uuid_length
+    seedfile %{
+      github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"
+    }
+    @seed.install
+
+    uuid = self.project["Seeds"]["JLToast"].uuid
+
+    assert uuid.length == 24, "UUID's should be 24 characters long"
+  end
+
   def test_uuid_preserve
     seedfile %{
       github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"


### PR DESCRIPTION
Xcodeproj UUID's should be 24 characters long. The project sort script provided by Apple expects them to be 24 characters and blows up if they're not.

This is a really basic way to fix it, so there may be a much better way. Perhaps even a refactoring.
