### PR TITLE
Reset local changes of seed directories before using seed.

### DIFF
--- a/lib/cocoaseeds/core.rb
+++ b/lib/cocoaseeds/core.rb
@@ -263,6 +263,10 @@ module Seeds
           tag.strip!
           if tag == seed.version
             say "Using #{name} (#{seed.version})"
+            `cd #{dirname} 2>&1 &&\
+             git reset HEAD --hard 2>&1 &&\
+             git checkout . 2>&1 &&\
+             git clean -fd 2>&1`
           else
             say "Installing #{name} #{seed.version} (was #{tag})".green
             `cd #{dirname} 2>&1 &&\


### PR DESCRIPTION
### Problem

**Seedfile**

``` ruby
swift_seedname_prefix!

github 'devxoul/SwiftyImage', '0.1.0', :files => 'SwiftyImage/SwiftyImage.swift'
```

At first installing,
- File `'Seeds/SwiftyImage/SwiftyImage.swift'` matches with `'SwiftyImage/SwiftyImage.swift'` from Seedfile, this file is processed by CocoaSeeds.
- CocoaSeeds renames `'Seeds/SwiftyImage/SwiftyImage.swift'` to `'Seeds/SwiftyImage/SwiftyImage_SwiftyImage.swift'`

From next,
- Renamed file `'Seeds/SwiftyImage/SwiftyImage_SwiftyImage.swift'` doesn't match `'SwiftyImage/SwiftyImage.swift'` from Seedfile, so CocoaSeeds skip this file.
### Solution

Rollback to original filename before using installed seeds.
### Related issue
- #20
