### PR TITLE
Force CocoaSeeds to use Xcodeproj 0.36.x

### DIFF
--- a/cocoaseeds.gemspec
+++ b/cocoaseeds.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.executables   = %w{ seed }
   s.require_paths = %w{ lib }
 
-  s.add_runtime_dependency "xcodeproj", "~> 0.24"
-  s.add_runtime_dependency "colorize", "~> 0.7"
+  s.add_runtime_dependency "xcodeproj", "~> 0.26.0"
+  s.add_runtime_dependency "colorize", "~> 0.7.0"
 
   s.required_ruby_version = ">= 2.0.0"
 end


### PR DESCRIPTION
CocoaSeeds causes an error with Xcodeproj 0.27.0.

Force CocoaSeeds to use Xcodeproj 0.36.x

```
$ seed install
/Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:128:in `require': cannot load such file -- xcodeproj/project/object (LoadError)
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:39:in `require'
    from /Library/Ruby/Gems/2.0.0/gems/xcodeproj-0.27.0/lib/xcodeproj/project.rb:4:in `<top (required)>'
    from /Library/Ruby/Gems/2.0.0/gems/cocoaseeds-0.2.0/lib/cocoaseeds/xcodehelper.rb:3:in `<module:Xcodeproj>'
    from /Library/Ruby/Gems/2.0.0/gems/cocoaseeds-0.2.0/lib/cocoaseeds/xcodehelper.rb:1:in `<top (required)>'
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Library/Ruby/Gems/2.0.0/gems/cocoaseeds-0.2.0/lib/cocoaseeds.rb:9:in `<module:Seeds>'
    from /Library/Ruby/Gems/2.0.0/gems/cocoaseeds-0.2.0/lib/cocoaseeds.rb:7:in `<top (required)>'
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Library/Ruby/Site/2.0.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Library/Ruby/Gems/2.0.0/gems/cocoaseeds-0.2.0/bin/seed:3:in `<top (required)>'
    from /usr/bin/seed:23:in `load'
    from /usr/bin/seed:23:in `<main>'
```
