### PR TITLE
Add support specifying Xcode project path in Seedfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ target :MyAppTest do
 end
 ```
 
+#### Specifying Xcode project file path
+
+If the .xcodeproj file is located in other location, you can specify the path in Seedfile.
+
+```ruby
+xcodeproj "path/to/Project.xcodeproj"
+
+target :MyApp do
+    github "devxoul/JLToast", "1.2.5", :files => "JLToast/*.{swift,h}"
+end
+```
+
 ### 2. Install dependencies
 
 After you are done with your Seedfile, it's time to load those libraries into your project. This is pretty simple. Just open the terminal, cd to your project directory and execute `seed install` command.

--- a/test/test.rb
+++ b/test/test.rb
@@ -26,6 +26,19 @@ class Test < Minitest::Test
   end
 
 
+  # Deletes existing project and creates new one in a subdirectory "MyApp".
+  def subdirectory_project
+    FileUtils.rm_rf(@project_filename)
+    new_dir = File.join(@project_dirname, "MyApp")
+    FileUtils.mkdir(new_dir)
+    @project_filename = File.join(new_dir, "TestProj.xcodeproj")
+    project = Xcodeproj::Project.new(@project_filename)
+    project.new_target(:application, "TestProj", :ios)
+    project.new_target(:test, "TestProjTests", :ios)
+    project.save
+  end
+
+
   def teardown
     FileUtils.rm_rf(@project_dirname)
   end

--- a/test/test_install.rb
+++ b/test/test_install.rb
@@ -140,3 +140,29 @@ class InstallTest
   end
 
 end
+
+
+class InstallTest
+
+  def test_install_xcodeproj
+    self.subdirectory_project
+    seedfile %{
+      xcodeproj "MyApp/TestProj.xcodeproj"
+      github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"
+    }
+    @seed.install
+
+    assert\
+      File.exists?(File.join(@seeds_dirname, "JLToast")),
+      "Directory Seeds/JLToast not exists."
+  end
+
+  def test_install_without_xcodeproj
+    self.subdirectory_project
+    seedfile %{
+      github "devxoul/JLToast", "1.2.2", :files => "JLToast/*.{h,swift}"
+    }
+    assert_raises Seeds::Exception do @seed.install end
+  end
+
+end


### PR DESCRIPTION
#### Specifying Xcode project file path

If the .xcodeproj file is located in other location, you can specify the path in Seedfile.

``` ruby
xcodeproj "path/to/Project.xcodeproj"

target :MyApp do
    github "devxoul/JLToast", "1.2.5", :files => "JLToast/*.{swift,h}"
end
```
