### PR TITLE
Insert files at first in Build Phase

### DIFF
--- a/lib/cocoaseeds/xcodehelper.rb
+++ b/lib/cocoaseeds/xcodehelper.rb
@@ -126,7 +126,7 @@ module Xcodeproj::Project::Object
       else
         build_file = project.new_with_uuid(PBXBuildFile, uuid)
         build_file.file_ref = file_ref
-        files << build_file
+        files.insert(0, build_file)
         build_file
       end
     end


### PR DESCRIPTION
If some files are at the end of build phase, Swift won't compile.

For example: https://github.com/devxoul/Then
