### PR TITLE
Use colored2 instead of colorize for CLI colors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source "https://rubygems.org"
 
-# runtime dependencies from gemspec
-gemspec = File.read("cocoaseeds.gemspec")
-gemspec.scan(/(?<=s\.add_runtime_dependency ).*/).each do |dependency|
-  eval "gem #{dependency}"
-end
+gemspec

--- a/cocoaseeds.gemspec
+++ b/cocoaseeds.gemspec
@@ -24,7 +24,9 @@ Gem::Specification.new do |s|
   s.require_paths = %w{ lib }
 
   s.add_runtime_dependency "xcodeproj", ">= 0.28"
-  s.add_runtime_dependency "colorize", "~> 0.7.0"
+  s.add_runtime_dependency "colored2", "~> 3.1"
+
+  s.add_development_dependency "rake"
 
   s.required_ruby_version = ">= 2.2.2"
 end

--- a/lib/cocoaseeds.rb
+++ b/lib/cocoaseeds.rb
@@ -1,4 +1,4 @@
-require 'colorize'
+require 'colored2'
 require 'digest'
 require 'fileutils'
 require 'xcodeproj'


### PR DESCRIPTION
Colorize and colored2 cannot be used at the same time due to
them defining conflicting entities in the global space. Since
CocoaPods uses colored2 and it's likely that someone would use
CocoaSeeds along side CocoaPods it's better to use colored2 in
CocoaSeeds too. 